### PR TITLE
Diets can be chosen when creating/editing a recipe

### DIFF
--- a/CookingCurator/Controllers/Manager.cs
+++ b/CookingCurator/Controllers/Manager.cs
@@ -249,12 +249,10 @@ namespace CookingCurator.Controllers
         {
             var diet_num = ds.Diets.SingleOrDefault(d => d.dietName == diet_Name);
 
-            IEnumerable<RECIPE> recipes = ds.Recipes.SqlQuery("Select * FROM RECIPES WHERE recipe_ID IN (SELECT recipe_ID FROM DIET_RECIPES WHERE diet_ID = " + diet_num.diet_ID + ")");
+            var recipes = ds.Recipes.SqlQuery("Select recipe_Id, title, rating, instructions, lastUpdated, author, verified, source_ID, source_Link, country, mealTimeType, content, 'Content-Type' AS 'Content_Type' FROM RECIPES WHERE recipe_ID IN (SELECT recipe_ID FROM DIET_RECIPES WHERE diet_ID = " + diet_num.diet_ID + ")");
 
             return recipes == null ? null : mapper.Map<IEnumerable<RECIPE>, IEnumerable<RecipeBaseViewModel>>(recipes);
         }
-
-
 
 
         public RecipeBaseViewModel RecipeAdd(RecipeAddViewForm recipe)

--- a/CookingCurator/Controllers/RecipeController.cs
+++ b/CookingCurator/Controllers/RecipeController.cs
@@ -64,6 +64,7 @@ namespace CookingCurator.Controllers
         {
             var recipe = m.RecipeWithIngredGetById(id.GetValueOrDefault());
             recipe.ingreds = m.ingredsForRecipeViewModel(id.GetValueOrDefault());
+            recipe.diets = m.dietsForRecipeViewModel(id.GetValueOrDefault());
             if(recipe.Content != null && recipe.Content_Type != null)
             {
                 string base64 = Convert.ToBase64String(recipe.Content);
@@ -140,6 +141,10 @@ namespace CookingCurator.Controllers
 
             form.ingredients = m.IngredientGetAll();
             form.selectedIngredsId = new string[0];
+
+            form.diets = m.DietGetAll();
+            form.selectedDietsId = new string[0];
+
             return View(form);
         }
 
@@ -151,6 +156,9 @@ namespace CookingCurator.Controllers
 
             form.ingredients = m.IngredientGetAll();
             form.selectedIngredsId = new string[0];
+
+            form.diets = m.DietGetAll();
+            form.selectedDietsId = new string[0];
 
             return View(form);
         }
@@ -182,6 +190,8 @@ namespace CookingCurator.Controllers
                         form.title = newItem.title;
                         form.ingredients = m.IngredientGetAll();
                         form.selectedIngredsId = new string[0];
+                        form.diets = m.DietGetAll();
+                        form.selectedDietsId = new string[0];
                         ModelState.AddModelError("", "Image size should be less than 50kb");
                         return View(form);
                     }
@@ -233,6 +243,8 @@ namespace CookingCurator.Controllers
                         form.title = newItem.title;
                         form.ingredients = m.IngredientGetAll();
                         form.selectedIngredsId = new string[0];
+                        form.diets = m.DietGetAll();
+                        form.selectedDietsId = new string[0];
                         ModelState.AddModelError("", "Image size should be less than 50kb");
                         return View(form);
                     }
@@ -268,15 +280,25 @@ namespace CookingCurator.Controllers
             {
                 return new HttpStatusCodeResult(HttpStatusCode.BadRequest);
             }
+
             Recipe_IngredViewModel recipe = m.mapper.Map<RecipeWithIngredBaseViewModel, Recipe_IngredViewModel>(m.RecipeWithIngredGetById(id));
+
             IEnumerable<IngredientBaseViewModel> ingredients = m.IngredientGetAll();
             String[] selectedIngreds = m.ingredsForRecipe(id).ToArray();
+
+            IEnumerable<DietDescViewModel> diets = m.DietGetAll();
+            String[] selectedDiets = m.dietsForRecipe(id).ToArray();
+
             if (recipe == null)
             {
                 return HttpNotFound();
             }
+
             recipe.ingredients = ingredients;
             recipe.selectedIngredsId = selectedIngreds;
+            recipe.diets = diets;
+            recipe.selectedDietsId = selectedDiets;
+
             if (recipe.Content != null && recipe.Content_Type != null)
             {
                 string base64 = Convert.ToBase64String(recipe.Content);
@@ -291,14 +313,22 @@ namespace CookingCurator.Controllers
         public ActionResult Edit(Recipe_IngredViewModel recipes, HttpPostedFileBase file)
         {
             Recipe_IngredViewModel recipe = m.mapper.Map<RecipeWithIngredBaseViewModel, Recipe_IngredViewModel>(m.RecipeWithIngredGetById(recipes.recipe_Id));
+
             IEnumerable<IngredientBaseViewModel> ingredients = m.IngredientGetAll();
             String[] selectedIngreds = m.ingredsForRecipe(recipes.recipe_Id).ToArray();
+            IEnumerable<DietDescViewModel> diets = m.DietGetAll();
+            String[] selectedDiets = m.dietsForRecipe(recipes.recipe_Id).ToArray();
+
             if (recipe == null)
             {
                 return HttpNotFound();
             }
+
             recipe.ingredients = ingredients;
             recipe.selectedIngredsId = selectedIngreds;
+            recipe.diets = diets;
+            recipe.selectedDietsId = selectedDiets;
+
             if (recipe.Content != null && recipe.Content_Type != null)
             {
                 string base64 = Convert.ToBase64String(recipe.Content);

--- a/CookingCurator/Controllers/RecipeController.cs
+++ b/CookingCurator/Controllers/RecipeController.cs
@@ -170,10 +170,55 @@ namespace CookingCurator.Controllers
         {
             // Validate the input
             if (!ModelState.IsValid)
+            {
+                newItem.ingredients = m.IngredientGetAll();
+                newItem.selectedIngredsId = new string[0];
+                newItem.diets = m.DietGetAll();
+                newItem.selectedDietsId = new string[0];
                 return View(newItem);
+            }
+
 
             try
             {
+
+                //Check for Diet conflict
+                bool compatDiet = true;
+
+                if (newItem.selectedDietsId.Length > 1)
+                {
+                    for (int i = 0; i < newItem.selectedDietsId.Length; i++)
+                    {
+                        //None apply cannot be selected with anything else
+                        if (newItem.selectedDietsId[i] == "10")
+                        {
+                            compatDiet = false;
+                        }
+
+                        //Vegan and Vegetarian shouldn't have meat
+                        if (newItem.selectedDietsId[i] == "8" || newItem.selectedDietsId[i] == "5")
+                        {
+                            for (int j = 0; j < newItem.selectedDietsId.Length; j++)
+                            {
+                                if (newItem.selectedDietsId[j] != "6" && newItem.selectedDietsId[j] != "5" && newItem.selectedDietsId[j] != "8")
+                                {
+                                    compatDiet = false;
+                                }
+                            }
+                        }
+                    }
+
+                    if (compatDiet == false)
+                    {
+                        ModelState.AddModelError("", "Incompatable Diets Selected");
+                        newItem.ingredients = m.IngredientGetAll();
+                        newItem.selectedIngredsId = new string[0];
+                        newItem.diets = m.DietGetAll();
+                        newItem.selectedDietsId = new string[0];
+                        return View(newItem);
+                    }
+                }
+
                 // Process the input
                 newItem.verified = true;
                 newItem.rating = 0;
@@ -223,10 +268,54 @@ namespace CookingCurator.Controllers
         {
             // Validate the input
             if (!ModelState.IsValid)
+            {
+                newItem.ingredients = m.IngredientGetAll();
+                newItem.selectedIngredsId = new string[0];
+                newItem.diets = m.DietGetAll();
+                newItem.selectedDietsId = new string[0];
                 return View(newItem);
+            }
+                
 
             try
             {
+                //Check for Diet conflict
+                bool compatDiet = true;
+
+                if (newItem.selectedDietsId.Length > 1)
+                {
+                    for (int i = 0; i < newItem.selectedDietsId.Length; i++)
+                    {
+                        //None apply cannot be selected with anything else
+                        if (newItem.selectedDietsId[i] == "10")
+                        {
+                            compatDiet = false;
+                        }
+
+                        //Vegan and Vegetarian shouldn't have meat
+                        if (newItem.selectedDietsId[i] == "8" || newItem.selectedDietsId[i] == "5")
+                        {
+                            for (int j = 0; j < newItem.selectedDietsId.Length; j++)
+                            {
+                                if (newItem.selectedDietsId[j] != "6" && newItem.selectedDietsId[j] != "5" && newItem.selectedDietsId[j] != "8")
+                                {
+                                    compatDiet = false;
+                                }
+                            }
+                        }
+                    }
+
+                    if (compatDiet == false)
+                    {
+                        ModelState.AddModelError("", "Incompatable Diets Selected");
+                        newItem.ingredients = m.IngredientGetAll();
+                        newItem.selectedIngredsId = new string[0];
+                        newItem.diets = m.DietGetAll();
+                        newItem.selectedDietsId = new string[0];
+                        return View(newItem);
+                    }
+                }
+
                 // Process the input
                 newItem.verified = false;
                 newItem.rating = 0;
@@ -319,15 +408,15 @@ namespace CookingCurator.Controllers
             IEnumerable<DietDescViewModel> diets = m.DietGetAll();
             String[] selectedDiets = m.dietsForRecipe(recipes.recipe_Id).ToArray();
 
-            if (recipe == null)
-            {
-                return HttpNotFound();
-            }
-
             recipe.ingredients = ingredients;
             recipe.selectedIngredsId = selectedIngreds;
             recipe.diets = diets;
             recipe.selectedDietsId = selectedDiets;
+
+            if (recipe == null)
+            {
+                return HttpNotFound();
+            }
 
             if (recipe.Content != null && recipe.Content_Type != null)
             {
@@ -342,7 +431,27 @@ namespace CookingCurator.Controllers
 
             try
             {
-                if(file != null && file.ContentLength > 0)
+
+                //Check for Diet conflict
+                bool compatDiet = true;
+
+                if (recipes.selectedDietsId.Length > 1)
+                {
+                    for (int i = 0; i < recipes.selectedDietsId.Length; i++)
+                    {
+                        if (recipes.selectedDietsId[i] == "10")
+                        {
+                            compatDiet = false;
+                        }
+                    }
+
+                    if (compatDiet == false)
+                    {
+                        ModelState.AddModelError("", "Incompatable Diets Selected");
+                        return View(recipe);
+                    }
+                }
+                if (file != null && file.ContentLength > 0)
                 {
                     if(file.ContentLength / 1024 > 50)
                     {
@@ -362,6 +471,7 @@ namespace CookingCurator.Controllers
                     ModelState.AddModelError("", "Error while editing a recipe. Please try again");
                     return View(recipe);
                 }
+
                 else
                 {
                     return RedirectToAction("Details", new { id = editedrecipe.recipe_Id });

--- a/CookingCurator/EntityModels/RecipeAddViewModel.cs
+++ b/CookingCurator/EntityModels/RecipeAddViewModel.cs
@@ -12,6 +12,7 @@ namespace CookingCurator.EntityModels
     {
         public int recipe_ID { get; set; }
         public int ingred_ID { get; set; }
+        public int diet_ID { get; set; }
     }
 
     public class RecipeAddViewForm
@@ -60,6 +61,11 @@ namespace CookingCurator.EntityModels
         public string[] selectedIngredsId { get; set; }
 
         public IEnumerable<IngredientBaseViewModel> ingredients;
+
+        [DisplayName("Diet Types")]
+        public string[] selectedDietsId { get; set; }
+
+        public IEnumerable<DietDescViewModel> diets;
     }
 
     public class RecipeAddViewModel
@@ -149,5 +155,10 @@ namespace CookingCurator.EntityModels
         public string[] selectedIngredsId { get; set; }
 
         public IEnumerable<IngredientBaseViewModel> ingredients;
+
+        [DisplayName("Diet Types")]
+        public string[] selectedDietsId { get; set; }
+
+        public IEnumerable<DietDescViewModel> diets;
     }
 }

--- a/CookingCurator/EntityModels/RecipeBaseViewModel.cs
+++ b/CookingCurator/EntityModels/RecipeBaseViewModel.cs
@@ -26,9 +26,12 @@ namespace CookingCurator.EntityModels
         public RecipeWithIngredBaseViewModel()
         {
             ingreds = new List<IngredientBaseViewModel>();
+            diets = new List<DietDescViewModel>();
         }
 
         public IEnumerable<IngredientBaseViewModel> ingreds { get; set; }
+
+        public IEnumerable<DietDescViewModel> diets { get; set; }
 
         public byte[] Content { get; set; }
 

--- a/CookingCurator/EntityModels/Recipe_IngredViewModel.cs
+++ b/CookingCurator/EntityModels/Recipe_IngredViewModel.cs
@@ -22,5 +22,10 @@ namespace CookingCurator.EntityModels
 
         public string fileResult { get; set; }
 
+        [DisplayName("Diet Types")]
+        public string[] selectedDietsId { get; set; }
+
+        public IEnumerable<DietDescViewModel> diets;
+
     }
 }

--- a/CookingCurator/Models/DataContext.cs
+++ b/CookingCurator/Models/DataContext.cs
@@ -24,6 +24,7 @@ namespace CookingCurator.Models
         public virtual DbSet<USER> Users { get; set; }
         public virtual DbSet<ALLERGY_INGREDS> Allergy_ingreds { get; set; }
         public virtual DbSet<DIET_INGREDS> Diet_Ingreds { get; set; }
+        public virtual DbSet<DIET_RECIPES> Diet_Recipes { get; set; }
         public virtual DbSet<RECIPE_USERS> Recipe_Users { get; set; }
     }
 }

--- a/CookingCurator/Views/Recipe/Create.cshtml
+++ b/CookingCurator/Views/Recipe/Create.cshtml
@@ -63,6 +63,14 @@
     </div>
 
     <div class="form-group">
+        @Html.LabelFor(model => model.selectedDietsId, htmlAttributes: new { @class = "control-label col-md-2" })
+        <div class="col-md-10">
+            <p>User 'control + left click' to select mutiple</p>
+            @Html.ListBoxFor(model => model.selectedDietsId, new MultiSelectList(Model.diets, "diet_ID", "dietName"), new { id = "multiSelect", multiple = "multiple" })
+        </div>
+    </div>
+
+    <div class="form-group">
         @Html.Label("Recipe Image", new { @class = "control-label col-md-2" })
         <div class="col-md-10">
             <input type="file" id="file" name="file" style="margin-bottom:5px" />

--- a/CookingCurator/Views/Recipe/Create.cshtml
+++ b/CookingCurator/Views/Recipe/Create.cshtml
@@ -65,8 +65,7 @@
     <div class="form-group">
         @Html.LabelFor(model => model.selectedDietsId, htmlAttributes: new { @class = "control-label col-md-2" })
         <div class="col-md-10">
-            <p>User 'control + left click' to select mutiple</p>
-            @Html.ListBoxFor(model => model.selectedDietsId, new MultiSelectList(Model.diets, "diet_ID", "dietName"), new { id = "multiSelect", multiple = "multiple" })
+            @Html.ListBoxFor(model => model.selectedDietsId, new MultiSelectList(Model.diets, "diet_ID", "dietName"), new { id = "multiSelect2", multiple = "multiple" })
         </div>
     </div>
 
@@ -95,6 +94,11 @@
     <script>
         $(function () {
             $("#multiSelect").chosen({
+                width: "100%"
+            });
+        })
+        $(function () {
+            $("#multiSelect2").chosen({
                 width: "100%"
             });
         })

--- a/CookingCurator/Views/Recipe/CreateVerified.cshtml
+++ b/CookingCurator/Views/Recipe/CreateVerified.cshtml
@@ -73,8 +73,7 @@
     <div class="form-group">
         @Html.LabelFor(model => model.selectedDietsId, htmlAttributes: new { @class = "control-label col-md-2" })
         <div class="col-md-10">
-            <p>User 'control + left click' to select mutiple</p>
-            @Html.ListBoxFor(model => model.selectedDietsId, new MultiSelectList(Model.diets, "diet_ID", "dietName"), new { id = "multiSelect", multiple = "multiple" })
+            @Html.ListBoxFor(model => model.selectedDietsId, new MultiSelectList(Model.diets, "diet_ID", "dietName"), new { id = "multiSelect2", multiple = "multiple" })
         </div>
     </div>
 
@@ -103,6 +102,11 @@
     <script>
         $(function () {
             $("#multiSelect").chosen({
+                width: "100%"
+            });
+        })
+        $(function () {
+            $("#multiSelect2").chosen({
                 width: "100%"
             });
         })

--- a/CookingCurator/Views/Recipe/CreateVerified.cshtml
+++ b/CookingCurator/Views/Recipe/CreateVerified.cshtml
@@ -71,9 +71,17 @@
     </div>
 
     <div class="form-group">
+        @Html.LabelFor(model => model.selectedDietsId, htmlAttributes: new { @class = "control-label col-md-2" })
+        <div class="col-md-10">
+            <p>User 'control + left click' to select mutiple</p>
+            @Html.ListBoxFor(model => model.selectedDietsId, new MultiSelectList(Model.diets, "diet_ID", "dietName"), new { id = "multiSelect", multiple = "multiple" })
+        </div>
+    </div>
+
+    <div class="form-group">
         @Html.Label("Recipe Image", new { @class = "control-label col-md-2" })
         <div class="col-md-10">
-            <input type="file" id="file" name="file" style="margin-bottom:5px"/>
+            <input type="file" id="file" name="file" style="margin-bottom:5px" />
             <span style="color:#989898">Note: Image size should be less than 50kb.</span>
         </div>
     </div>

--- a/CookingCurator/Views/Recipe/Details.cshtml
+++ b/CookingCurator/Views/Recipe/Details.cshtml
@@ -3,6 +3,7 @@
 @{
     ViewBag.Title = "Details";
     Layout = "~/Views/Shared/_Layout.cshtml";
+    bool checkEmpty = Model.diets.Any();
 }
 
 <header>
@@ -108,7 +109,24 @@
             }
         </dd>
 
+        @if (checkEmpty)
+        {
+            <dt>
+                Applicable Diets:
+            </dt>
+
+            <dd>
+
+                @foreach (var d in Model.diets)
+                {
+                    <span>@d.dietName</span><br />
+                }
+
+            </dd>
+        }
+
     </dl>
+
 </section>
 
 <aside>

--- a/CookingCurator/Views/Recipe/Edit.cshtml
+++ b/CookingCurator/Views/Recipe/Edit.cshtml
@@ -98,8 +98,7 @@
     <div class="form-group">
         @Html.LabelFor(model => model.selectedDietsId, htmlAttributes: new { @class = "control-label col-md-2" })
         <div class="col-md-10">
-            <p>User 'control + left click' to select mutiple</p>
-            @Html.ListBoxFor(model => model.selectedDietsId, new MultiSelectList(Model.diets, "diet_ID", "dietName"), new { id = "multiSelect", multiple = "multiple" })
+            @Html.ListBoxFor(model => model.selectedDietsId, new MultiSelectList(Model.diets, "diet_ID", "dietName"), new { id = "multiSelect2", multiple = "multiple" })
         </div>
     </div>
 
@@ -139,6 +138,11 @@
     <script>
         $(function () {
             $("#multiSelect").chosen({
+                width: "100%"
+            });
+        })
+        $(function () {
+            $("#multiSelect2").chosen({
                 width: "100%"
             });
         })

--- a/CookingCurator/Views/Recipe/Edit.cshtml
+++ b/CookingCurator/Views/Recipe/Edit.cshtml
@@ -93,22 +93,30 @@
         <div class="col-md-10">
             @Html.ListBoxFor(model => model.selectedIngredsId, new MultiSelectList(Model.ingredients, "ingred_ID", "ingred_Name"), new { id = "multiSelect", multiple = "multiple" })
         </div>
-
     </div>
 
-    @if(!String.IsNullOrEmpty(@Model.fileResult)){
     <div class="form-group">
-        @Html.Label("Recipe Image", htmlAttributes: new { @class = "control-label col-md-2" })
-        <div class="col-md-10" id="divImg" style="height:200px;width:200px;">
-            <img src="@Model.fileResult" style="height:200px" alt="Recipe Image" />
+        @Html.LabelFor(model => model.selectedDietsId, htmlAttributes: new { @class = "control-label col-md-2" })
+        <div class="col-md-10">
+            <p>User 'control + left click' to select mutiple</p>
+            @Html.ListBoxFor(model => model.selectedDietsId, new MultiSelectList(Model.diets, "diet_ID", "dietName"), new { id = "multiSelect", multiple = "multiple" })
         </div>
     </div>
+
+    @if (!String.IsNullOrEmpty(@Model.fileResult))
+    {
+        <div class="form-group">
+            @Html.Label("Recipe Image", htmlAttributes: new { @class = "control-label col-md-2" })
+            <div class="col-md-10" id="divImg" style="height:200px;width:200px;">
+                <img src="@Model.fileResult" style="height:200px" alt="Recipe Image" />
+            </div>
+        </div>
     }
 
     <div class="form-group">
         @Html.Label("Alter Image", new { @class = "control-label col-md-2" })
         <div class="col-md-10">
-            <input type="file" id="file" name="file" style="margin-bottom:5px"/>
+            <input type="file" id="file" name="file" style="margin-bottom:5px" />
             <span style="color:#989898">Note: Image size should be less than 50kb.</span>
         </div>
     </div>


### PR DESCRIPTION
Diets can now be applied when creating and editing a recipe.  Diets will show on the details page _if_ at least one was selected.  Functions very similarly to ingredients with recipes.

**Note:**  Currently does not have logic to prevent users from selecting incompatible diet options (such as preventing users from selecting "none apply" with other options).  I will be working on this as soon as I have time, but wanted the current additions to be reviewed first.